### PR TITLE
add maxlength limit

### DIFF
--- a/headerFilter.go
+++ b/headerFilter.go
@@ -60,6 +60,6 @@ func init() {
 
 	// RegistHeadFilter(&HeadFilterBase{})
 	RegistHeadFilter(&mqHeadFilter{})
-	// RegistHeadFilter(&upstreamHeadFilter{})
-	// RegistHeadFilter(&multipartFilter{})
+	RegistHeadFilter(&upstreamHeadFilter{})
+	RegistHeadFilter(&multipartFilter{})
 }

--- a/lhttpDefine.go
+++ b/lhttpDefine.go
@@ -24,6 +24,7 @@ var (
 	protocolName            = "LHTTP"
 	protocolNameWithVersion = "LHTTP/1.0"
 	protocolLength          = 9
+	MaxLength				= 40960
 )
 
 var (

--- a/mqFilter.go
+++ b/mqFilter.go
@@ -19,8 +19,9 @@ func (*mqHeadFilter) AfterRequestFilterHandle(ws *WsHandler) {
 		channels = strings.Split(value, " ")
 		for _, c := range channels {
 			if conn,err:=mq.Subscribe(c, ws.subscribeCallback); nil == err{
-				log.Println(conn,err)
 				ws.subscribe_nats_conn[c] = conn
+			}else{
+				log.Println("Subscribe Error",err)
 			}
 			// log.Print("subscribe channel: ", c)
 		}

--- a/wsHandler.go
+++ b/wsHandler.go
@@ -216,12 +216,20 @@ func StartServer(ws *Conn) {
 		if err != nil {
 			break
 		}
-
-		if len(data) <= protocolLength {
+		l:=len(data)
+		if l <= protocolLength {
 			//TODO how to provide other protocol
 			// log.Print("TODO provide other protocol")
 			continue
 		}
+
+		l:=len(data)
+		if l > MaxLength {
+			//TODO how to provide other protocol
+			// log.Print("TODO provide other protocol")
+			continue
+		}
+
 
 		if data[:protocolLength] != protocolNameWithVersion {
 			//TODO how to provide other protocol


### PR DESCRIPTION
-	// RegistHeadFilter(&upstreamHeadFilter{})
-	// RegistHeadFilter(&multipartFilter{})

增加单个包大小限制，减轻服务器转发压力　(目前为40K，在 lhttpDefine.go 中定义）
恢复被错误注释掉的包头处理....
